### PR TITLE
Satisfy peer dependency of ts-essentials v6.0.5

### DIFF
--- a/packages/earljs/package.json
+++ b/packages/earljs/package.json
@@ -44,6 +44,9 @@
     "test:fix": "yarn lint:fix && yarn format:fix && yarn typecheck && yarn test",
     "release": "yarn lint && yarn format && yarn typecheck && yarn test && yarn build"
   },
+  "peerDependencies": {
+    "typescript": ">=3.7.0"
+  },
   "dependencies": {
     "debug": "^4.1.1",
     "jest-snapshot": "^26.6.2",


### PR DESCRIPTION
Reported by yarn:
```sh
$ yarn explain peer-requirements pc0199
➤ YN0000: earljs@npm:0.1.12 doesn't provide typescript, breaking the following requirements:
➤ YN0000: ts-essentials@npm:6.0.7 [688f2] → >=3.7.0 ✘
```

See: https://github.com/krzkaczor/ts-essentials/blob/v6.0.5/package.json#L31

Thanks, enjoying this library!