### PR TITLE
Oh wow, we need to move TypedEventFilter to @typechain/ethers/common.d.ts

### DIFF
--- a/packages/earljs/src/Expectation.ts
+++ b/packages/earljs/src/Expectation.ts
@@ -20,11 +20,13 @@ import { toReferentiallyEqual } from './validators/toReferentiallyEqual'
 import { toThrow } from './validators/toThrow'
 import { ValidatorsFor } from './validators/types'
 
+export interface ExpectationOverrides {}
+
 export interface ExpectationOptions {
   extraMessage?: string
 }
 
-export type Expectation<T> = Modifiers<T> & ValidatorsFor<T>
+export type Expectation<T> = Modifiers<T> & ValidatorsFor<T> & ExpectationOverrides
 
 /**
  * @internal

--- a/packages/earljs/src/index.ts
+++ b/packages/earljs/src/index.ts
@@ -1,5 +1,5 @@
 export { Expect, expect, Expect as ExpectInterface } from './expect'
-export { Expectation, ExpectationOptions } from './Expectation'
+export { Expectation, ExpectationOptions, ExpectationOverrides } from './Expectation'
 export type { SmartEqRules } from './isEqual/rules'
 export { Mock, mockFn } from './mocks'
 export type { Validators } from './validators/types'

--- a/packages/ethereum-plugin/src/validators/toEmit.ts
+++ b/packages/ethereum-plugin/src/validators/toEmit.ts
@@ -1,8 +1,53 @@
-import { Control, Expectation, getControl, isEqual } from 'earljs/internals'
-import { Contract, providers } from 'ethers'
+import { Control, getControl, isEqual } from 'earljs/internals'
+import { BaseContract, EventFilter, providers } from 'ethers'
 import { LogDescription } from 'ethers/lib/utils'
 
-export async function toEmit(this: Expectation<any>, contract: Contract, event: string, args?: any[]): Promise<void> {
+// #region this could be exported from "@typechain/ethers"
+export interface TypedEvent<TArgsArray extends Array<any> = any, TArgsObject = any> extends Event {
+  args: TArgsArray & TArgsObject
+}
+
+export interface TypedEventFilter<_TEvent extends TypedEvent> extends EventFilter {}
+// #endregion
+
+type EventNames<TContract extends BaseContract> = keyof TContract['filters']
+type EventArgs<TContract extends BaseContract, TEventName extends EventNames<TContract>> = ReturnType<
+  TContract['filters'][TEventName]
+> extends TypedEventFilter<infer T>
+  ? [T, T['args']]
+  : never
+
+type StringKeys<T extends object> = { [P in keyof T as P extends `${number}` | number ? never : P]: T[P] }
+
+type NumberKeys<T extends any[]> = { [I in keyof T as I extends `${number}` ? I : never]: T[I] }
+
+// prettier-ignore
+type NumberDictAsTuple<T extends Record<number, unknown>> = 
+  unknown extends T[1] ? T[0] :
+  unknown extends T[2] ? [T[0], T[1]] :
+  unknown extends T[3] ? [T[0], T[1], T[2]] :
+  unknown extends T[4] ? [T[0], T[1], T[2], T[3]] :
+  unknown extends T[5] ? [T[0], T[1], T[2], T[3], T[4]] :
+  unknown extends T[6] ? [T[0], T[1], T[2], T[3], T[4], T[5]] :
+  unknown extends T[7] ? [T[0], T[1], T[2], T[3], T[4], T[5], T[6]] :
+  unknown extends T[8] ? [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]] :
+  unknown extends T[9] ? [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]] :
+  [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]]
+
+type EventArgsObject<TContract extends BaseContract, TEventName extends EventNames<TContract>> = StringKeys<
+  Omit<EventArgs<TContract, TEventName>, keyof unknown[]>
+>
+
+type EventArgsArray<TContract extends BaseContract, TEventName extends EventNames<TContract>> = NumberDictAsTuple<
+  NumberKeys<EventArgs<TContract, TEventName>>
+>
+
+export async function toEmit<TContract extends BaseContract, TEventName extends EventNames<TContract>>(
+  this: any,
+  contract: TContract,
+  event: TEventName,
+  args?: { EventFilter: ReturnType<TContract['filters'][TEventName]> },
+): Promise<void> {
   const ctrl = getControl(this) as Control<
     | providers.TransactionResponse
     | providers.TransactionReceipt
@@ -11,7 +56,7 @@ export async function toEmit(this: Expectation<any>, contract: Contract, event: 
 
   let hasEvent = false
   try {
-    contract.interface.getEvent(event)
+    contract.interface.getEvent(event.toString())
     hasEvent = true
   } catch {}
   if (!hasEvent) {

--- a/packages/ethereum-plugin/test/validators/toEmit.test.ts
+++ b/packages/ethereum-plugin/test/validators/toEmit.test.ts
@@ -3,6 +3,47 @@ import { expect } from 'earljs'
 import { BigNumber } from 'ethers'
 
 import { Events, Events__factory } from '../fixtures/generated'
+import { TypedEventFilter } from '../fixtures/generated/common'
+
+// #region @krzkaczor is this what you meant?
+
+type __EventsEventNames = keyof Events['filters']
+type __EventsEventArgs = {
+  [P in __EventsEventNames]: ReturnType<Events['filters'][P]> extends TypedEventFilter<infer T> ? T['args'] : never
+}
+
+type StringKeys<T extends object> = { [P in keyof T as P extends `${number}` | number ? never : P]: T[P] }
+
+type __EventsEventArgsObjects = {
+  [P in keyof __EventsEventArgs]: StringKeys<Omit<__EventsEventArgs[P], keyof unknown[]>>
+}
+
+// HOVER HERE
+type __OneEventObject = __EventsEventArgsObjects['One']
+
+type NumberKeys<T extends any[]> = { [I in keyof T as I extends `${number}` ? I : never]: T[I] }
+
+// prettier-ignore
+type NumberDictAsTuple<T extends Record<number, unknown>> = 
+  unknown extends T[1] ? T[0] :
+  unknown extends T[2] ? [T[0], T[1]] :
+  unknown extends T[3] ? [T[0], T[1], T[2]] :
+  unknown extends T[4] ? [T[0], T[1], T[2], T[3]] :
+  unknown extends T[5] ? [T[0], T[1], T[2], T[3], T[4]] :
+  unknown extends T[6] ? [T[0], T[1], T[2], T[3], T[4], T[5]] :
+  unknown extends T[7] ? [T[0], T[1], T[2], T[3], T[4], T[5], T[6]] :
+  unknown extends T[8] ? [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7]] :
+  unknown extends T[9] ? [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8]] :
+  [T[0], T[1], T[2], T[3], T[4], T[5], T[6], T[7], T[8], T[9]]
+
+type __EventsEventArgArrays = {
+  [P in keyof __EventsEventArgs]: NumberDictAsTuple<NumberKeys<__EventsEventArgs[P]>>
+}
+
+// AND HOVER HERE TOO
+type __OneEventArray = __EventsEventArgArrays['One']
+
+// #region @krzkaczor
 
 describe('toEmit', function () {
   this.timeout(10000)
@@ -19,7 +60,7 @@ describe('toEmit', function () {
   })
 
   it('checks that event was emitted', async () => {
-    await expect(events.emitOne()).toEmit(events, 'One')
+    await expect(events.emitOne()).toEmit2(events, 'One')
   })
 
   it('checks that event was not emitted', async () => {

--- a/packages/ethereum-plugin/types.d.ts
+++ b/packages/ethereum-plugin/types.d.ts
@@ -8,3 +8,9 @@ declare module 'earljs' {
   interface Validators extends createPlugin.ValidatorsOf<typeof plugin> {}
   interface SmartEqRules extends createPlugin.SmartEqRulesOf<typeof plugin> {}
 }
+
+declare module 'earljs' {
+  interface ExpectationOverrides {
+    toEmit2: Validators['toEmit']
+  }
+}


### PR DESCRIPTION
This is karma for using a phantom type. @krzkaczor, I've sent you a wall of text on Discord.