### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/packages/earljs/README.md
+++ b/packages/earljs/README.md
@@ -8,6 +8,7 @@
     <a href="/package.json"><img alt="Software License" src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square"></a>
     <img alt="All contributors" src="https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square">
     <a href="https://discord.gg/wQDkeDgzgv"><img alt="Join our discord!" src="https://img.shields.io/discord/895381864922091630.svg?color=7289da&label=deth&logo=discord&style=flat-square"></a>
+    <a href="https://www.gitpoap.io/gh/dethcrypto/TypeChain"><img alt="GitPOAP eligible" src="https://public-api.gitpoap.io/v1/repo/dethcrypto/TypeChain/badge"><a/>
   </p>
 </p>
 


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie