### PR TITLE
#284: Improve error texts for arrays of objects

### DIFF
--- a/packages/earl/src/format/formatCompact.test.ts
+++ b/packages/earl/src/format/formatCompact.test.ts
@@ -58,10 +58,10 @@ describe('formatCompact', () => {
     [{ x: 1, y: 1 }, '{ x: 1, y: 1 }'],
     [
       { x: 'long value long value', y: 'long value long value' },
-      '{ 2 entries }',
+      '{ x: "long va...", y: "long va..." }',
     ],
     [{ x: 1, y: 1, z: 1 }, '{ x: 1, y: 1, z: 1 }'],
-    [{ x: 'long value', y: 'long value', z: 'long value' }, '{ 3 entries }'],
+    [{ x: 'long value', y: 'long value', z: 'long value' }, '{ x: "long value", y: "long value", z: "long value" }'],
     [[], '[]'],
     [[1, 2], '[1, 2]'],
     [
@@ -74,6 +74,11 @@ describe('formatCompact', () => {
     [earl.anything(), 'expect.anything()'],
     [[earl.anything()], '[expect.anything()]'],
     [new (class Foo {})(), 'Foo {}'],
+    [
+      [{ _id: 42, foo: 'bar' }, { _id: 43, foo: 'baz' }, { _id: 44, lorem: 'ipsum' }, { _id: 45, lorem: 'ipsum', 
+      'long value long value': false }],
+      '[{ _id: 42, foo: "bar" }, { _id: 43, foo: "baz" }, { _id: 44, lorem: "ipsum" }, { _id: 45, "long va...": false, lorem: "ipsum" }]'
+    ]
   ]
 
   for (const [value, expected] of testCases) {

--- a/packages/earl/src/format/formatUnknown.ts
+++ b/packages/earl/src/format/formatUnknown.ts
@@ -172,11 +172,7 @@ export function formatUnknown(
   const beginning = items.join(' ')
 
   if (options.inline) {
-    let jointEntries = entries.map((x) => x[1]).join(', ')
-    if (jointEntries.length > options.maxLineLength) {
-      jointEntries =
-        entries.length === 1 ? '1 entry' : `${entries.length} entries`
-    }
+    const jointEntries = entries.map((x) => x[1]).join(', ')
     if (type === 'Array') {
       return toLine(`${beginning}${jointEntries}]`)
     } else {

--- a/packages/earl/src/validators/objects/toHaveSubset.test.ts
+++ b/packages/earl/src/validators/objects/toHaveSubset.test.ts
@@ -107,7 +107,7 @@ describe(toHaveSubset.name, () => {
           prop3: earl.a(Array),
         })
       }).to.throw(
-        'The value { 3 entries } does has a subset of { 2 entries }, but it was expected not to.',
+        'The value { prop: true, prop2: "string", prop3: [] } does has a subset of { prop2: expect.a(String), prop3: expect.a(Array) }, but it was expected not to.',
       )
     })
 

--- a/packages/earl/src/validators/objects/toHaveSubset.test.ts
+++ b/packages/earl/src/validators/objects/toHaveSubset.test.ts
@@ -78,7 +78,7 @@ describe(toHaveSubset.name, () => {
       expect(() => {
         earl({ prop: true }).not.toHaveSubset({ prop: true })
       }).to.throw(
-        'The value { prop: true } does has a subset of { prop: true }, but it was expected not to.',
+        'The value { prop: true } does have a subset of { prop: true }, but it was expected not to.',
       )
     })
 
@@ -92,7 +92,7 @@ describe(toHaveSubset.name, () => {
           prop2: 'string',
         })
       }).to.throw(
-        'The value { prop: true, prop2: "string" } does has a subset of { prop: true, prop2: "string" }, but it was expected not to.',
+        'The value { prop: true, prop2: "string" } does have a subset of { prop: true, prop2: "string" }, but it was expected not to.',
       )
     })
 
@@ -107,7 +107,7 @@ describe(toHaveSubset.name, () => {
           prop3: earl.a(Array),
         })
       }).to.throw(
-        'The value { prop: true, prop2: "string", prop3: [] } does has a subset of { prop2: expect.a(String), prop3: expect.a(Array) }, but it was expected not to.',
+        'The value { prop: true, prop2: "string", prop3: [] } does have a subset of { prop2: expect.a(String), prop3: expect.a(Array) }, but it was expected not to.',
       )
     })
 

--- a/packages/earl/src/validators/objects/toHaveSubset.ts
+++ b/packages/earl/src/validators/objects/toHaveSubset.ts
@@ -38,6 +38,6 @@ export function toHaveSubset(control: Control, expected: Subset): void {
   control.assert({
     success: subset(expected)(control.actual),
     reason: `The value ${actualInline} does not have a subset of ${expectedInline}, but it was expected to.`,
-    negatedReason: `The value ${actualInline} does has a subset of ${expectedInline}, but it was expected not to.`,
+    negatedReason: `The value ${actualInline} does have a subset of ${expectedInline}, but it was expected not to.`,
   })
 }

--- a/packages/earl/src/validators/objects/toInclude.ts
+++ b/packages/earl/src/validators/objects/toInclude.ts
@@ -61,7 +61,7 @@ declare module '../../expect.js' {
 registerValidator('toInclude', toInclude)
 
 export function toInclude(control: Control, ...items: unknown[]) {
-  const actualInline = formatCompact(control.actual)
+  const actualInline = formatCompact(control.actual, 100)
   const itemsInline = formatItems(items)
 
   if (items.length === 0) {
@@ -76,7 +76,7 @@ export function toInclude(control: Control, ...items: unknown[]) {
 }
 
 function formatItems(items: unknown[]) {
-  const joined = languageJoin(items.map((x) => formatCompact(x, 20)))
+  const joined = languageJoin(items.map((x) => formatCompact(x, 100)))
   return joined.length > 50 ? `all of: ${items.length} items` : joined
 }
 


### PR DESCRIPTION
I think it is not helpful to shorten arrays or objects and always better to print shortened objects.

I also fixed a typo in toHaveSubset's negatedReason.