### PR TITLE
Add lazy calculations

### DIFF
--- a/.changeset/lemon-plants-march.md
+++ b/.changeset/lemon-plants-march.md
@@ -1,0 +1,5 @@
+---
+"earl": patch
+---
+
+Improve performance by making some error messages lazy

--- a/packages/earl/src/errors/AssertionError.ts
+++ b/packages/earl/src/errors/AssertionError.ts
@@ -26,11 +26,19 @@ export class AssertionError extends Error {
 
   static getLocation(name: string) {
     const error = new Error('message')
-    const cleaned = getCleanStack(error)
-    const parsed = ErrorStackParser.parse({ stack: cleaned } as Error)
+    let cleaned: string | undefined
+    let parsed: ErrorStackParser.StackFrame[] | undefined
     return {
-      file: parsed[0]?.fileName,
-      stack: formatStack(name, parsed),
+      file: () => {
+        cleaned = cleaned ?? getCleanStack(error)
+        parsed = parsed ?? ErrorStackParser.parse({ stack: cleaned } as Error)
+        return parsed[0]?.fileName
+      },
+      stack: () => {
+        cleaned = cleaned ?? getCleanStack(error)
+        parsed = parsed ?? ErrorStackParser.parse({ stack: cleaned } as Error)
+        return formatStack(name, parsed)
+      },
     }
   }
 }

--- a/packages/earl/src/isEqual/isEqual.perf.test.ts
+++ b/packages/earl/src/isEqual/isEqual.perf.test.ts
@@ -1,0 +1,45 @@
+/* eslint-disable symbol-description */
+/* eslint-disable no-new-wrappers */
+
+import { expect } from '../expect.js'
+
+describe('isEqual performance', function () {
+  this.timeout(10_000)
+
+  const dataObject = {
+    id: 1,
+    name: 'John Doe',
+    email: 'john.doe@example.com',
+    address: {
+      city: 'New York',
+      state: 'New York',
+      country: 'USA',
+      zip: '10001',
+      street: '123 Main St',
+    },
+    profile: {
+      gender: 'Male',
+      birthdate: '1980-01-01',
+      pictureUrl: 'https://example.com/john-doe.jpg',
+    },
+    preferences: {
+      language: 'English',
+      currency: 'USD',
+    },
+    roles: ['User', 'Admin'],
+  }
+
+  it('measure', function () {
+    const repeat = 5
+    const iterations = 2000
+    const testValue = [dataObject, dataObject, dataObject]
+
+    for (let i = 0; i < repeat; i++) {
+      const time = Date.now()
+      for (let j = 0; j < iterations; j++) {
+        expect(testValue).toEqual(testValue)
+      }
+      console.log(`${Date.now() - time}ms`)
+    }
+  })
+})

--- a/packages/earl/src/validators/other/toEqual.ts
+++ b/packages/earl/src/validators/other/toEqual.ts
@@ -54,13 +54,15 @@ declare module '../../expect.js' {
 registerValidator('toEqual', toEqual)
 
 export function toEqual(control: Control, expected: unknown) {
-  const actualInline = formatCompact(control.actual)
-  const expectedInline = formatCompact(expected)
+  const actualInline = () => formatCompact(control.actual)
+  const expectedInline = () => formatCompact(expected)
 
   control.assert({
     success: isEqual(control.actual, expected),
-    reason: `The value ${actualInline} is not equal to ${expectedInline}, but it was expected to be equal.`,
-    negatedReason: `The value ${actualInline} is equal to ${expectedInline}, but it was expected not to be equal.`,
+    reason: () =>
+      `The value ${actualInline()} is not equal to ${expectedInline()}, but it was expected to be equal.`,
+    negatedReason: () =>
+      `The value ${actualInline()} is equal to ${expectedInline()}, but it was expected not to be equal.`,
     actual: control.actual,
     expected,
   })


### PR DESCRIPTION
Added lazy calculations for formatted messages and stack traces.
Only `toEqual` assertion has been modified.
Synthetic test run time reduced from 800ms to 15ms