### PR TITLE
build: 📦 use ts-essentials@10

### DIFF
--- a/.changeset/tasty-frogs-tan.md
+++ b/.changeset/tasty-frogs-tan.md
@@ -1,0 +1,5 @@
+---
+"website": patch
+---
+
+Use ts-essentials@10

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -22,7 +22,7 @@
     "@types/lodash": "^4.14.191",
     "fast-glob": "^3.2.12",
     "lodash": "^4.17.21",
-    "ts-essentials": "^9.3.1",
+    "ts-essentials": "^10.0.0",
     "ts-morph": "^17.0.1",
     "vitepress": "1.0.0-alpha.51"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,6 @@ importers:
         specifier: ^3.22.5
         version: 3.22.5
 
-  packages/earl/dist/cjs: {}
-
   packages/website:
     dependencies:
       '@algolia/client-search':
@@ -160,8 +158,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       ts-essentials:
-        specifier: ^9.3.1
-        version: 9.3.1(typescript@5.4.5)
+        specifier: ^10.0.0
+        version: 10.0.0(typescript@5.4.5)
       ts-morph:
         specifier: ^17.0.1
         version: 17.0.1
@@ -4870,10 +4868,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-essentials@9.3.1(typescript@5.4.5):
-    resolution: {integrity: sha512-9CChSvQMyVRo29Vb1A2jbs+LKo3d/bAf+ndSaX0T8cEiy/HChVaRN/HY5DqUryZ8hZ6uol9bEgCnGmnDbwBR9Q==}
+  /ts-essentials@10.0.0(typescript@5.4.5):
+    resolution: {integrity: sha512-77FHNJEyysF9+1s4G6eejuA1lxw7uMchT3ZPy3CIbh7GIunffpshtM8pTe5G6N5dpOzNevqRHew859ceLWVBfw==}
     peerDependencies:
-      typescript: '>=4.1.0'
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       typescript: 5.4.5
     dev: false


### PR DESCRIPTION
## Summary

Hey!

We've just released ts-essentials@10 - https://github.com/ts-essentials/ts-essentials/releases/tag/v10.0.0 so updating the package for the website of your library

@sz-piotr please let me know if you'd like to remove `conditional-type-checks` in favour to `ts-essentials`. You can easily replace:

```ts
type _ = AssertTrue<
  IsExact<
    MockFunction<[number, number], number>,
    MockFunctionOf<Operation>
  >
>
```

with just:

```ts
isExact<MockFunction<[number, number], number>>()(fn);
```

in `packages/earl/src/mocks/mockFn.test.ts` but I will leave it up to you to decide